### PR TITLE
Remove ServiceConfiguration.ConfigError() arg

### DIFF
--- a/lib/vk_client.js
+++ b/lib/vk_client.js
@@ -9,7 +9,7 @@ VK.requestCredential = function (options, credentialRequestCompleteCallback) {
 
     var config = ServiceConfiguration.configurations.findOne({service: 'vk'});
     if (!config) {
-        credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError("Service not configured"));
+        credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError());
         return;
     }
 


### PR DESCRIPTION
Hi,
Method ServiceConfiguration.ConfigError() takes one arg serviceName for string "Service `serviceName` not configured" or nothing if we want pure string "Service not configured"
[link to method](https://github.com/meteor/meteor/blob/832e6fe44f3635cae060415d6150c0105f2bf0f6/packages/service-configuration/service_configuration_common.js)